### PR TITLE
Implemented time range for stacky.py search

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Usage: stacky <command>
     search  - 'search <service-name> <field> <value>'
               search for rawdata events belonging to any service - nova, glance
               or generic according to any field and its value.
+              You can also pass limit on results, and duration of interest:
+              'search <service-name> <field> <value> <limit> "<start datetime>" "<end datetime>"'
 ```
 
 NOTE: *kpi* and *watch* commands are currently disabled. Will be fixed soon.
@@ -126,4 +128,122 @@ $ python stacky.py request req-5539174d-0cd9-40d9-a7d5-5aa883c20033
 | 16373592 |   | 2013-04-09 14:31:57.497054 | cellB  |    scheduler.run_instance.end    | nova-scheduler.foo.com |          |          |                      |
 | 16373603 |   | 2013-04-09 14:32:11.773272 | cellB  |     compute.instance.update      |                   computehostA                    | building | building |      scheduling      |
 ... (and so on)
+```
+
+### List all deployments configured on stachtach to monitor for events
+```
+$ python stacky.py deployments
++---+--------------------+
+| # |        Name        |
++---+--------------------+
+| 1 | j-g2s4-kilo-1-4319 |
+| 2 | j-g2s8-kilo-1-4547 |
++---+--------------------+
+```
+
+### Search for rawdata events belonging to any service for a given time frame
+Example: Searching all events on nova service for deployment node 1, between '2017-07-27 23:31:38' and '2017-07-30 23:31:40', limiting 20 results.
+
+```
+$ python stacky.py search nova deployment_id 1 20 '2017-07-27 23:31:38' '2017-07-30 23:31:40'
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
+|  #  | ? |            When            |     Deployment     |             Event             |        Host        | State  | State' | Task' |
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
+| 145 |   | 2017-07-30 20:19:42.607541 | j-g2s4-kilo-1-4319 |  compute.instance.reboot.end  | j-g2s4-kilo-2-5327 | active |        |       |
+| 144 |   | 2017-07-30 20:19:38.613726 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 143 | E | 2017-07-27 23:31:38.236789 | j-g2s4-kilo-1-4319 |     compute.libvirt.error     | j-g2s4-kilo-2-5327 |        |        |       |
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
+```
+
+Example: Searching all events on nova service for tenant ca83e6bc934d4d6caf1ac94f974ab9ae, between '2017-07-27 23:31:38' and '2017-07-30 23:31:40', limiting 20 results.
+```
+$ python stacky.py search nova tenant ca83e6bc934d4d6caf1ac94f974ab9ae  20 '2017-07-27 23:31:38' '2017-07-30 23:31:40'
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
+|  #  | ? |            When            |     Deployment     |             Event             |        Host        | State  | State' | Task' |
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
+| 145 |   | 2017-07-30 20:19:42.607541 | j-g2s4-kilo-1-4319 |  compute.instance.reboot.end  | j-g2s4-kilo-2-5327 | active |        |       |
+| 144 |   | 2017-07-30 20:19:38.613726 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
+```
+
+Example: Searching all events on nova service for event 'compute.instance.reboot.start':
+```
+$ python stacky.py search nova event compute.instance.reboot.start
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
+|  #  | ? |            When            |     Deployment     |             Event             |        Host        | State  | State' | Task' |
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
+| 251 |   | 2017-08-15 05:32:37.625245 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 249 |   | 2017-08-10 05:22:55.653390 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 247 |   | 2017-08-10 05:22:48.999138 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 245 |   | 2017-08-10 05:21:37.574440 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 243 |   | 2017-08-10 05:21:07.403328 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 241 |   | 2017-08-10 05:02:24.202181 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 239 |   | 2017-08-10 04:41:58.422175 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 237 |   | 2017-08-10 04:10:12.768241 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 235 |   | 2017-08-10 00:47:32.034192 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 233 |   | 2017-08-10 00:39:27.910512 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 231 |   | 2017-08-10 00:37:59.212735 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 229 |   | 2017-08-09 23:43:47.315095 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 227 |   | 2017-08-09 23:41:41.292486 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 225 |   | 2017-08-09 23:32:07.371495 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 223 |   | 2017-08-09 23:28:11.373375 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 221 |   | 2017-08-09 23:20:54.732545 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 219 |   | 2017-08-09 23:14:16.520805 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 217 |   | 2017-08-09 23:11:48.224939 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 215 |   | 2017-08-09 23:10:31.182164 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 213 |   | 2017-08-09 23:09:10.657919 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 191 |   | 2017-08-08 21:52:00.192223 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 189 |   | 2017-08-08 21:49:38.887607 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 187 |   | 2017-08-08 21:32:32.096817 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 185 |   | 2017-08-08 21:05:13.394918 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 183 |   | 2017-08-08 21:02:07.845803 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 181 |   | 2017-08-08 20:58:24.451998 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 179 |   | 2017-08-08 20:37:16.692284 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 177 |   | 2017-08-08 20:31:39.747477 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 175 |   | 2017-08-08 19:25:04.886559 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 173 |   | 2017-08-08 19:21:23.320767 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 171 |   | 2017-08-08 18:18:22.291989 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 169 |   | 2017-08-08 17:32:55.464050 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 167 |   | 2017-08-08 00:29:47.512147 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 165 |   | 2017-08-08 00:27:23.214272 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 163 |   | 2017-08-08 00:18:52.455834 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 161 |   | 2017-08-08 00:07:12.829193 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 159 |   | 2017-08-08 00:02:42.862015 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 157 |   | 2017-08-02 00:30:58.844547 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 155 |   | 2017-08-02 00:05:35.758426 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 153 |   | 2017-08-01 19:05:41.057068 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 151 |   | 2017-08-01 18:25:20.860796 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 146 |   | 2017-07-31 22:50:51.406844 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 144 |   | 2017-07-30 20:19:38.613726 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 127 |   | 2017-07-25 22:31:03.735723 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 125 |   | 2017-07-25 19:15:14.541101 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 119 |   | 2017-07-25 00:20:58.847064 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 117 |   | 2017-07-24 23:37:18.258383 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 111 |   | 2017-07-24 20:57:47.015922 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+| 105 |   | 2017-07-21 17:14:04.253091 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
+|  99 |   | 2017-07-21 01:00:05.464092 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | error  |        |       |
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
+```
+
+Example: Searching all events on nova service for event 'compute.instance.reboot.start' limiting 5 results:
+```
+$ python stacky.py search nova event compute.instance.reboot.start 5
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
+|  #  | ? |            When            |     Deployment     |             Event             |        Host        | State  | State' | Task' |
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
+| 251 |   | 2017-08-15 05:32:37.625245 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 249 |   | 2017-08-10 05:22:55.653390 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 247 |   | 2017-08-10 05:22:48.999138 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 245 |   | 2017-08-10 05:21:37.574440 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
+| 243 |   | 2017-08-10 05:21:07.403328 | j-g2s8-kilo-1-4547 | compute.instance.reboot.start | j-g2s8-kilo-2-6549 | active |        |       |
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
+```
+Example: Searching all events on nova service for event 'compute.instance.reboot.start' limiting 5 results between time range :'2017-07-27 23:31:38' '2017-07-30 23:31:40'
+```
+$ python stacky.py search nova event compute.instance.reboot.start 5 '2017-07-27 23:31:38' '2017-07-30 23:31:40'
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
+|  #  | ? |            When            |     Deployment     |             Event             |        Host        | State  | State' | Task' |
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
+| 144 |   | 2017-07-30 20:19:38.613726 | j-g2s4-kilo-1-4319 | compute.instance.reboot.start | j-g2s4-kilo-2-5327 | active |        |       |
++-----+---+----------------------------+--------------------+-------------------------------+--------------------+--------+--------+-------+
 ```

--- a/stacky.py
+++ b/stacky.py
@@ -168,6 +168,11 @@ def _str_to_datetime(str):
     return datetime.datetime.strptime(str, "%Y-%m-%d %H:%M:%S")
 
 
+def datetime_str_to_epoch(user_time_str):
+    d = datetime.datetime.strptime(user_time_str, "%Y-%m-%d %H:%M:%S")
+    return (d - datetime.datetime(1970, 1, 1)).total_seconds()
+
+
 if __name__ == '__main__':
     if len(sys.argv) == 1:
         print """Usage: stacky <command>
@@ -235,6 +240,7 @@ if __name__ == '__main__':
 
     if cmd == 'search':
         limit = None
+        when_min = when_max = None
         if len(sys.argv) >= 4:
             field = safe_arg(3)
             value = safe_arg(4)
@@ -242,8 +248,14 @@ if __name__ == '__main__':
         if len(sys.argv) == 6:
             limit = safe_arg(5)
             limit = sys.argv[5]
+        if len(sys.argv) == 8:
+            when_min = safe_arg(6)
+            when_max = safe_arg(7)
 
         params = {'field': field, 'value': value}
+        if when_min is not None:
+            params['when_min'] = datetime_str_to_epoch(when_min)
+            params['when_max'] = datetime_str_to_epoch(when_max)
         if limit:
             params['limit'] = limit
         params['service'] = service


### PR DESCRIPTION
Stacktach support when_min and when_max as filter arguments for GET
/stacky/search/ . This patch implements support to pass when_min
and when_max in stacky.py search option.
The when_min and when_max datetime are accepted in friendly format
as seen with results of stacky.py search and other options.

Added examples on how to use time range for 'search' feature of stacky
on README.md